### PR TITLE
サーバーのportを変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       - ./:/usr/app
     command: 'sh ./prisma/start.sh'
     ports:
-      - '3000:3000'
       - '5555:5555'
+      - '8888:8888'
     tty: true
     depends_on:
       - db

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,6 @@ async function bootstrap() {
     AppModule,
     new FastifyAdapter(),
   );
-  await app.listen(3000);
+  await app.listen(8888);
 }
 bootstrap();


### PR DESCRIPTION
# 概要
clientを3000ポートで扱うために、serverのポートを8888に変更する

# 関連 Issue
#4

# 変更内容
- デフォルトでは`app.listen`に3000番ポートを指定しているのを、8888番ポートに更新
- 合わせて、docker-composeを更新
