### PR TITLE
文章校正機能のスキーマ叩き台

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# DB
+.env
+mysql/

--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -32,7 +32,3 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-
-# Prisma
-.env
-mysql/

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -6,3 +6,20 @@ datasource db {
 generator client {
   provider = "prisma-client-js"
 }
+
+model ProofreadingData {
+  dataId Int @id @default(autoincrement())
+  text   String
+  rules  LintRule[]
+  result LintResult[]
+}
+model LintRule {
+  ruleId  String @unique
+  isValid Boolean
+}
+model LintResult {
+  resultId Int @id @default(autoincrement())
+  message  String
+  line     Int
+  column   Int
+}

--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -1,11 +1,20 @@
 import { Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
+import { join } from 'path';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaService } from './prisma.service';
+import { ProofreadingDataResolver } from './resolvers/proofreadingData.resolver';
+
 @Module({
-  imports: [GraphQLModule.forRoot({})],
+  imports: [
+    GraphQLModule.forRoot({
+      autoSchemaFile: join(process.cwd(), 'src/schema.gql'),
+      debug: true,
+      playground: true,
+    }),
+  ],
   controllers: [AppController],
-  providers: [AppService, PrismaService],
+  providers: [AppService, PrismaService, ProofreadingDataResolver],
 })
 export class AppModule {}

--- a/packages/server/src/models/lintResult.model.ts
+++ b/packages/server/src/models/lintResult.model.ts
@@ -1,0 +1,13 @@
+import { ObjectType, Field, Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class LintResult {
+  @Field((_type) => Int)
+  resultId: number;
+  @Field((_type) => String)
+  message: string;
+  @Field((_type) => Int)
+  line: number;
+  @Field((_type) => Int)
+  column: number;
+}

--- a/packages/server/src/models/lintRule.model.ts
+++ b/packages/server/src/models/lintRule.model.ts
@@ -1,0 +1,9 @@
+import { ObjectType, Field } from '@nestjs/graphql';
+
+@ObjectType()
+export class LintRule {
+  @Field((_type) => String)
+  ruleId: string;
+  @Field((_type) => Boolean)
+  isValid: boolean;
+}

--- a/packages/server/src/models/proofreadingData.model.ts
+++ b/packages/server/src/models/proofreadingData.model.ts
@@ -1,0 +1,17 @@
+import { ObjectType, Field, Int } from '@nestjs/graphql';
+import { LintResult } from './lintResult.model';
+import { LintRule } from './lintRule.model';
+// import { LintRule } from '@/models/lintRule.model';
+// import { LintResult } from '@/models/lintResult.model';
+
+@ObjectType()
+export class ProofreadingData {
+  @Field((_type) => Int)
+  dataId: number;
+  @Field((_type) => String)
+  text: string;
+  @Field((_type) => LintRule)
+  rules: LintRule[];
+  @Field((_type) => LintResult)
+  result: LintResult[];
+}

--- a/packages/server/src/resolvers/proofreadingData.resolver.ts
+++ b/packages/server/src/resolvers/proofreadingData.resolver.ts
@@ -1,0 +1,20 @@
+import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
+import { ProofreadingData } from '../models/proofreadingData.model';
+import { PrismaService } from '../prisma.service';
+
+@Resolver((of) => ProofreadingData)
+export class ProofreadingDataResolver {
+  constructor(private prisma: PrismaService) {}
+
+  @Query((returns) => [ProofreadingData])
+  async proofreadingDatas() {
+    return this.prisma.proofreadingData.findMany();
+  }
+
+  @Mutation((returns) => ProofreadingData)
+  async createProofreading(
+    @Args({ name: 'text', type: () => String }) text: string,
+  ) {
+    return this.prisma.proofreadingData.create({ data: { text: text } });
+  }
+}

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -1,0 +1,30 @@
+# ------------------------------------------------------
+# THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+# ------------------------------------------------------
+
+type LintRule {
+  ruleId: String!
+  isValid: Boolean!
+}
+
+type LintResult {
+  resultId: Int!
+  message: String!
+  line: Int!
+  column: Int!
+}
+
+type ProofreadingData {
+  dataId: Int!
+  text: String!
+  rules: LintRule!
+  result: LintResult!
+}
+
+type Query {
+  proofreadingDatas: [ProofreadingData!]!
+}
+
+type Mutation {
+  createProofreading(text: String!): ProofreadingData!
+}


### PR DESCRIPTION
# 概要
スキーマとモデルの叩き台を作成

# 関連 Issue
#15 

# 変更内容
- `.gitignore`を整備
- `schema.prisma`にスキーマを作成
- modelとresolverを作成
- `schema.gql`の自動生成

# 確認事項
- [x] playgroundから`proofreadingDatas`と`createProofreading`を叩けることを確認
![image](https://user-images.githubusercontent.com/40588536/103164430-773bf880-484e-11eb-95d9-9c2a859841ef.png)
