### PR TITLE
サーバーをhttp://localhost:8888/で開けなかった問題の修正

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -5,3 +5,4 @@ COPY ./packages/server/package*.json ./
 RUN npm ci
 
 COPY . .
+EXPOSE 5555 8888

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -10,6 +10,6 @@ async function bootstrap() {
     AppModule,
     new FastifyAdapter(),
   );
-  await app.listen(8888);
+  await app.listen(8888,'0.0.0.0');
 }
 bootstrap();


### PR DESCRIPTION
# 概要
T/O
フロントからサーバーのAPIを叩く時、ポートが固定されていないと不便だったので

ref
```
By default, Fastify listens only on the localhost 127.0.0.1 interface (read more). If you want to accept connections on other hosts, you should specify '0.0.0.0' in the listen() call:
```
https://docs.nestjs.com/techniques/performance#adapter

# 関連 Issue
#4 

# 変更内容
- DockerfileにEXPOSEを追加
- Fastifyの`app.listen`第二引数に`'0.0.0.0'`を追加

# 確認事項
- [x] ポートが転送されず、http://localhost:8888 でアクセスできることを確認
![image](https://user-images.githubusercontent.com/40588536/103186776-3fdc5300-4905-11eb-9781-1c5f23febcc0.png)

