### PR TITLE
Apollo Clientの導入

### DIFF
--- a/packages/front/graphql/client.ts
+++ b/packages/front/graphql/client.ts
@@ -1,0 +1,7 @@
+import { ApolloClient, InMemoryCache } from '@apollo/client';
+
+export const client = new ApolloClient({
+  // MEMO: いずれ本番環境のURIに差し替える
+  uri: `http://localhost:8888/graphql`,
+  cache: new InMemoryCache(),
+});

--- a/packages/front/jest.config.ts
+++ b/packages/front/jest.config.ts
@@ -7,6 +7,7 @@ const config: Config.InitialOptions = {
     '\\.(css|scss)$': 'identity-obj-proxy',
     '^@/(.+)': '<rootDir>/src/$1',
     '^@test/(.+)': '<rootDir>/test/$1',
+    '^@graphql/(.+)': '<rootDir>/graphql/$1',
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(ts|tsx)$'],

--- a/packages/front/package-lock.json
+++ b/packages/front/package-lock.json
@@ -71,6 +71,33 @@
         "cross-fetch": "3.0.6"
       }
     },
+    "@apollo/client": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.6.tgz",
+      "integrity": "sha512-XSm/STyNS8aHdDigLLACKNMHwI0qaQmEHWHtTP+jHe/E1wZRnn66VZMMgwKLy2V4uHISHfmiZ4KpUKDPeJAKqg==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.5.2",
+        "@wry/equality": "^0.3.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.11.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.13.1",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^2.0.0",
+        "ts-invariant": "^0.6.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+          "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
+        }
+      }
+    },
     "@ardatan/aggregate-error": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz",
@@ -1958,8 +1985,7 @@
     "@graphql-typed-document-node/core": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
-      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
-      "dev": true
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg=="
     },
     "@hapi/accept": {
       "version": "5.0.1",
@@ -3020,6 +3046,11 @@
         "@types/jest": "*"
       }
     },
+    "@types/ungap__global-this": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz",
+      "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g=="
+    },
     "@types/websocket": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.1.tgz",
@@ -3043,6 +3074,16 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
       "dev": true
+    },
+    "@types/zen-observable": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.1.tgz",
+      "integrity": "sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ=="
+    },
+    "@ungap/global-this": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.3.tgz",
+      "integrity": "sha512-MuHEpDBurNVeD6mV9xBcAN2wfTwuaFQhHuhWkJuXmyVJ5P5sBCw+nnFpdfb0tAvgWkfefWCsAoAsh7MTUr3LPg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -3199,6 +3240,22 @@
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "@wry/context": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.3.tgz",
+      "integrity": "sha512-n0uKHiWpf2ArHhmcHcUsKA+Dj0gtye/h56VmsDcoMRuK/ZPFeHKi8ck5L/ftqtF12ZbQR9l8xMPV7y+xybaRDA==",
+      "requires": {
+        "tslib": "^1.14.1"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.1.tgz",
+      "integrity": "sha512-8/Ftr3jUZ4EXhACfSwPIfNsE8V6WKesdjp+Dxi78Bej6qlasAxiz0/F8j0miACRj9CL4vC5Y5FsfwwEYAuhWbg==",
+      "requires": {
+        "tslib": "^1.14.1"
       }
     },
     "@xtuc/ieee754": {
@@ -6468,8 +6525,7 @@
     "graphql-tag": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
-      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==",
-      "dev": true
+      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
     },
     "graphql-upload": {
       "version": "11.0.0",
@@ -6674,6 +6730,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "hosted-git-info": {
@@ -10286,6 +10350,14 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "optimism": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.2.tgz",
+      "integrity": "sha512-kJkpDUEs/Rp8HsAYYlDzyvQHlT6YZa95P+2GGNR8p/VvsIkt6NilAk7oeTvMRKCq7BeclB7+bmdIexog2859GQ==",
+      "requires": {
+        "@wry/context": "^0.5.2"
+      }
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -12853,6 +12925,16 @@
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
+    "ts-invariant": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.0.tgz",
+      "integrity": "sha512-caoafsfgb8QxdrKzFfjKt627m4i8KTtfAiji0DYJfWI4A/S9ORNNpzYuD9br64kyKFgxn9UNaLLbSupam84mCA==",
+      "requires": {
+        "@types/ungap__global-this": "^0.3.1",
+        "@ungap/global-this": "^0.4.2",
+        "tslib": "^1.9.3"
+      }
+    },
     "ts-jest": {
       "version": "26.4.4",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.4.tgz",
@@ -13870,6 +13952,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     }
   }
 }

--- a/packages/front/package.json
+++ b/packages/front/package.json
@@ -10,6 +10,7 @@
     "codegen": "graphql-codegen"
   },
   "dependencies": {
+    "@apollo/client": "^3.3.6",
     "graphql": "^15.4.0",
     "next": "10.0.4",
     "react": "17.0.1",

--- a/packages/front/src/pages/_app.tsx
+++ b/packages/front/src/pages/_app.tsx
@@ -1,6 +1,6 @@
 import { ApolloProvider } from '@apollo/client';
-import { client } from 'graphql/client';
-import '../styles/globals.css';
+import { client } from '@graphql/client';
+import '@/styles/globals.css';
 
 function MyApp({ Component, pageProps }) {
   return (

--- a/packages/front/src/pages/_app.tsx
+++ b/packages/front/src/pages/_app.tsx
@@ -1,7 +1,13 @@
-import '../styles/globals.css'
+import { ApolloProvider } from '@apollo/client';
+import { client } from 'graphql/client';
+import '../styles/globals.css';
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <ApolloProvider client={client}>
+      <Component {...pageProps} />
+    </ApolloProvider>
+  );
 }
 
-export default MyApp
+export default MyApp;

--- a/packages/front/src/pages/index.tsx
+++ b/packages/front/src/pages/index.tsx
@@ -1,7 +1,12 @@
-import Head from 'next/head'
-import styles from '../styles/Home.module.css'
+import Head from 'next/head';
+import styles from '@/styles/Home.module.css';
+import { useQuery } from '@apollo/client';
+import { ProofreadingDatasDocument } from '@graphql/graphql-operations';
 
 export default function Home() {
+  const result = useQuery(ProofreadingDatasDocument);
+  //TODO: 確認用、後で削除
+  console.log(result);
   return (
     <div className={styles.container}>
       <Head>
@@ -61,5 +66,5 @@ export default function Home() {
         </a>
       </footer>
     </div>
-  )
+  );
 }

--- a/packages/front/test/pages/index.spec.tsx
+++ b/packages/front/test/pages/index.spec.tsx
@@ -1,10 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import Home from '@/pages/index';
+import { MockedProvider } from '@apollo/client/testing';
 
 describe(`Home`, () => {
   it('render Next.js text', () => {
-    render(<Home />);
+    render(
+      <MockedProvider>
+        <Home />
+      </MockedProvider>,
+    );
     expect(
       screen.getByRole('heading', { name: /welcome to next\.js!/i }),
     ).toHaveTextContent('Next.js!');

--- a/packages/front/tsconfig.json
+++ b/packages/front/tsconfig.json
@@ -16,7 +16,8 @@
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"],
-      "@test/*": ["test/*"]
+      "@test/*": ["test/*"],
+      "@graphql/*": ["graphql/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
# 概要
フロントでGraphQLAPIを扱うために、Apollo Clientを導入する。

# 関連 Issue
#15 

# 変更内容
- ApolloClientのパッケージをインストール
- http://localhost:8888/graphql と接続
- 絶対パスを扱うように修正
- app全体でApolloClientを扱えるように、ApolloProviderにclientを渡す
- ルートページでQueryの結果をログ出力

# 確認事項
- [ ] `useQuery`の結果を受け取れていることをログで確認
https://github.com/faronan/next-app/blob/bf633b31ef3d1ec610ed7855b83dabacb5e87567/packages/front/src/pages/index.tsx#L7-L9

![image](https://user-images.githubusercontent.com/40588536/103194025-89d33200-4921-11eb-9dad-c73311e0c6c4.png)

# 補足
loading stateなどのテストケースを分けるときは、公式のドキュメントを参考に
https://www.apollographql.com/docs/react/development-testing/testing/