### PR TITLE
#20 の実装漏れ

### DIFF
--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -15,7 +15,8 @@ model ProofreadingData {
 }
 
 model LintRule {
-  ruleName  String @unique
+  ruleId Int @id @default(autoincrement())
+  ruleName  String
   proofreadingData ProofreadingData? @relation(fields: [proofreadingDataId], references: [dataId])
   proofreadingDataId Int?
 }

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -9,6 +9,9 @@ async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule,
     new FastifyAdapter(),
+    {
+      logger: ['log'],
+    },
   );
   await app.listen(8888, '0.0.0.0');
 }

--- a/packages/server/src/models/lintRule.model.ts
+++ b/packages/server/src/models/lintRule.model.ts
@@ -1,7 +1,9 @@
-import { ObjectType, Field } from '@nestjs/graphql';
+import { ObjectType, Field, ID } from '@nestjs/graphql';
 
 @ObjectType()
 export class LintRule {
+  @Field((_type) => ID)
+  ruleId: number;
   @Field((_type) => String)
   ruleName: string;
 }

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -3,6 +3,7 @@
 # ------------------------------------------------------
 
 type LintRule {
+  ruleId: ID!
   ruleName: String!
 }
 

--- a/packages/server/src/services/proofreadingData.service.ts
+++ b/packages/server/src/services/proofreadingData.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/services/prisma.service';
 import { LintRuleService } from '@/services/lintRule.service';
 import { LintResultService } from '@/services/lintResult.service';
+import { ProofreadingData } from '@/models/proofreadingData.model';
+import { LintRule } from '@/models/lintRule.model';
+import { LintResult } from '@/models/lintResult.model';
 
 @Injectable()
 export class ProofreadingDataService {
@@ -23,8 +26,43 @@ export class ProofreadingDataService {
   async create(text: string, ruleNames: string[]) {
     const rules = await this.ruleService.create(ruleNames);
     const result = await this.resultService.create(text, ruleNames);
-    return await this.prismaService.proofreadingData.create({
-      data: { text: text, rules: rules, result: result },
-    });
+    const prismaProofreadingData = await this.prismaService.proofreadingData.create(
+      {
+        data: { text: text, rules: rules, result: result },
+      },
+    );
+
+    // MEMO: prismaService.proofreadingData.createの戻り値にはruleとresultが含まれていない
+    // ruleとresultを入れたProofreadingDataを新たに作成してからクライアントに返す
+    const transformProofreadingData = this.transform(
+      prismaProofreadingData,
+      ruleNames,
+      result['create'],
+    );
+
+    return transformProofreadingData;
   }
+
+  private transform = (
+    prismaProofreadingData: { dataId: number; text: string },
+    ruleNames: string[],
+    result: LintResult[],
+  ) => {
+    const proofreadingData = new ProofreadingData();
+    proofreadingData.dataId = prismaProofreadingData.dataId;
+    proofreadingData.text = prismaProofreadingData.text;
+    proofreadingData.rules = ruleNames.map((n) => {
+      const rule = new LintRule();
+      rule.ruleName = n;
+      return rule;
+    });
+    proofreadingData.result = result.map((r) => {
+      const result = new LintResult();
+      result.message = r.message;
+      result.line = r.line;
+      result.column = r.column;
+      return result;
+    });
+    return proofreadingData;
+  };
 }

--- a/packages/server/test/services/proofreadingData.service.spec.ts
+++ b/packages/server/test/services/proofreadingData.service.spec.ts
@@ -62,10 +62,13 @@ describe('ProofreadingDataService', () => {
       lintResultService['create'] = lintResultServiceCreateMock;
       const prismaCreateMock = jest.fn();
       prismaService.proofreadingData['create'] = prismaCreateMock;
+      const proofreadingDataTransformMock = jest.fn();
+      proofreadingDataService['transform'] = proofreadingDataTransformMock;
 
       await proofreadingDataService.create(testText, testRules);
       expect(lintRuleServiceCreateMock).toHaveBeenCalled();
       expect(lintResultServiceCreateMock).toHaveBeenCalled();
+      expect(proofreadingDataTransformMock).toHaveBeenCalled();
       expect(prismaCreateMock).toHaveBeenCalled();
       expect(prismaCreateMock.mock.calls[0][0]).toEqual(expectedArg);
     });


### PR DESCRIPTION
# 概要
#20 の実装が甘かった部分を修正

# 関連 Issue
#15

# 変更内容
- LintRuleのunique keyとしてidを用いる
- Nest内でconsole logを有効にする
- `createProofreading`の返り値にruleとresultを含める
