### PR TITLE
userとcreatedAtが取得できなかった問題の修正

### DIFF
--- a/packages/server/src/models/proofreadingData.model.ts
+++ b/packages/server/src/models/proofreadingData.model.ts
@@ -7,9 +7,10 @@ export class ProofreadingData {
   @Field((_type) => ID)
   dataId: number;
   text: string;
-  @Field((_type) => User)
+  @Field((_type) => User, { nullable: true })
   user: User;
   @Field((_type) => [LintResult])
   result?: LintResult[];
-  created_at: Date;
+  @Field({ nullable: true })
+  createdAt: Date;
 }

--- a/packages/server/src/models/user.model.ts
+++ b/packages/server/src/models/user.model.ts
@@ -4,9 +4,9 @@ import { ProofreadingData } from '@/models/proofreadingData.model';
 @ObjectType()
 export class User {
   @Field((_type) => ID)
-  userId: number;
-  userName: string;
-  userEmail: string;
+  id: number;
+  name: string;
+  email: string;
   @Field((_type) => [ProofreadingData])
   proofreadingDatas: ProofreadingData[];
 }

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -3,10 +3,10 @@
 # ------------------------------------------------------
 
 type User {
-  userId: ID!
+  id: ID!
   proofreadingDatas: [ProofreadingData!]!
-  userName: String!
-  userEmail: String!
+  name: String!
+  email: String!
 }
 
 type LintResult {
@@ -20,10 +20,10 @@ type LintResult {
 
 type ProofreadingData {
   dataId: ID!
-  user: User!
+  user: User
   result: [LintResult!]
+  createdAt: DateTime
   text: String!
-  created_at: DateTime!
 }
 
 """

--- a/packages/server/src/services/proofreadingData.service.ts
+++ b/packages/server/src/services/proofreadingData.service.ts
@@ -2,9 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@/services/prisma.service';
 import { UserService } from '@/services/user.service';
 import { LintResultService } from '@/services/lintResult.service';
-import { ProofreadingData } from '@/models/proofreadingData.model';
-import { LintResult } from '@/models/lintResult.model';
-import { User } from '@/models/user.model';
 
 @Injectable()
 export class ProofreadingDataService {
@@ -34,45 +31,13 @@ export class ProofreadingDataService {
     const prismaProofreadingData = await this.prismaService.proofreadingData.create(
       {
         data: { text: text, user: user, result: result },
+        include: {
+          user: true,
+          result: true,
+        },
       },
     );
 
-    // MEMO: prismaService.proofreadingData.createの戻り値にはuserとresultが含まれていない
-    // userとresultを入れたProofreadingDataを新たに作成してからクライアントに返す
-    const transformProofreadingData = this.transform(
-      prismaProofreadingData,
-      userEmail,
-      userName,
-      result['create'],
-    );
-
-    return transformProofreadingData;
+    return prismaProofreadingData;
   }
-
-  private transform = (
-    prismaProofreadingData: { dataId: number; text: string; userId: number },
-    userEmail: string,
-    userName: string,
-    result: LintResult[],
-  ) => {
-    const proofreadingData = new ProofreadingData();
-    proofreadingData.dataId = prismaProofreadingData.dataId;
-    proofreadingData.text = prismaProofreadingData.text;
-
-    const user = new User();
-    user.userId = prismaProofreadingData.userId;
-    user.userEmail = userEmail;
-    user.userName = userName;
-    proofreadingData.user = user;
-
-    proofreadingData.result = result.map((r) => {
-      const result = new LintResult();
-      result.message = r.message;
-      result.ruleName = r.ruleName;
-      result.line = r.line;
-      result.column = r.column;
-      return result;
-    });
-    return proofreadingData;
-  };
 }

--- a/packages/server/test/services/proofreadingData.service.spec.ts
+++ b/packages/server/test/services/proofreadingData.service.spec.ts
@@ -58,6 +58,10 @@ describe('ProofreadingDataService', () => {
           user: testReturnUsers,
           result: testReturnResults,
         },
+        include: {
+          user: true,
+          result: true,
+        },
       };
 
       const UserServiceCreateMock = jest.fn(() =>
@@ -70,8 +74,6 @@ describe('ProofreadingDataService', () => {
       lintResultService['create'] = lintResultServiceCreateMock;
       const prismaCreateMock = jest.fn();
       prismaService.proofreadingData['create'] = prismaCreateMock;
-      const proofreadingDataTransformMock = jest.fn();
-      proofreadingDataService['transform'] = proofreadingDataTransformMock;
 
       await proofreadingDataService.create(
         testText,
@@ -81,7 +83,6 @@ describe('ProofreadingDataService', () => {
       );
       expect(UserServiceCreateMock).toHaveBeenCalled();
       expect(lintResultServiceCreateMock).toHaveBeenCalled();
-      expect(proofreadingDataTransformMock).toHaveBeenCalled();
       expect(prismaCreateMock).toHaveBeenCalled();
       expect(prismaCreateMock.mock.calls[0][0]).toEqual(expectedArg);
     });


### PR DESCRIPTION
# 概要
userとcreatedAt問題の修正、原因はmodelクラスのプロパティ名とprismaのスキーマ名が異なっていたこと

# 関連 PR
#22 

# 変更内容
- ProofreadingDataのUserがnullの場合を許容
- Userモデルのプロパティ名全てとProofreadingDataのcreated_at(⇨ createdAt)を修正
- `proofreadingData.create`時にPrismaの仕組みでuserとresultを取得する

# 確認事項
- [x] userとcreatedAtが正常に取得できていることを確認
![image](https://user-images.githubusercontent.com/40588536/104728952-09af2800-577b-11eb-9899-ec7139190d2e.png)

# 補足
prisma/clientに生えているのはType、resolverで扱うにはクラスにする必要があるから結局modelクラスは必要
