### PR TITLE
過去の校正結果を表示する機能を作成

### DIFF
--- a/packages/front/graphql/graphql-operations.ts
+++ b/packages/front/graphql/graphql-operations.ts
@@ -16,16 +16,16 @@ export type Scalars = {
 
 export type User = {
   __typename?: 'User';
-  userId: Scalars['ID'];
-  proofreadingDatas: Array<ProofreadingData>;
-  userName: Scalars['String'];
-  userEmail: Scalars['String'];
+  id: Scalars['ID'];
+  proofreadingDataList: Array<ProofreadingData>;
+  name: Scalars['String'];
+  email: Scalars['String'];
 };
 
 export type LintResult = {
   __typename?: 'LintResult';
   resultId: Scalars['ID'];
-  proofreadingDatas: Array<ProofreadingData>;
+  proofreadingDataList: Array<ProofreadingData>;
   ruleName: Scalars['String'];
   message: Scalars['String'];
   line: Scalars['Float'];
@@ -35,16 +35,16 @@ export type LintResult = {
 export type ProofreadingData = {
   __typename?: 'ProofreadingData';
   dataId: Scalars['ID'];
-  user: User;
+  user?: Maybe<User>;
   result?: Maybe<Array<LintResult>>;
+  createdAt?: Maybe<Scalars['DateTime']>;
   text: Scalars['String'];
-  created_at: Scalars['DateTime'];
 };
 
 
 export type Query = {
   __typename?: 'Query';
-  proofreadingDatas: Array<ProofreadingData>;
+  proofreadingDataList: Array<ProofreadingData>;
 };
 
 export type Mutation = {
@@ -73,16 +73,32 @@ export type CreateProofreadingMutation = (
   { __typename?: 'Mutation' }
   & { createProofreading: (
     { __typename?: 'ProofreadingData' }
-    & Pick<ProofreadingData, 'dataId' | 'text'>
-    & { user: (
-      { __typename?: 'User' }
-      & Pick<User, 'userName'>
-    ), result?: Maybe<Array<(
+    & Pick<ProofreadingData, 'text'>
+    & { result?: Maybe<Array<(
       { __typename?: 'LintResult' }
       & Pick<LintResult, 'ruleName' | 'message' | 'line' | 'column'>
     )>> }
   ) }
 );
 
+export type ProofreadingDataListQueryVariables = Exact<{ [key: string]: never; }>;
 
-export const CreateProofreadingDocument: DocumentNode<CreateProofreadingMutation, CreateProofreadingMutationVariables> = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"createProofreading"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"proofreading"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AddProofreadingDataInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createProofreading"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"proofreading"},"value":{"kind":"Variable","name":{"kind":"Name","value":"proofreading"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"dataId"}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"userName"}}]}},{"kind":"Field","name":{"kind":"Name","value":"result"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ruleName"}},{"kind":"Field","name":{"kind":"Name","value":"message"}},{"kind":"Field","name":{"kind":"Name","value":"line"}},{"kind":"Field","name":{"kind":"Name","value":"column"}}]}}]}}]}}]};
+
+export type ProofreadingDataListQuery = (
+  { __typename?: 'Query' }
+  & { proofreadingDataList: Array<(
+    { __typename?: 'ProofreadingData' }
+    & Pick<ProofreadingData, 'text' | 'createdAt'>
+    & { user?: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'name'>
+    )>, result?: Maybe<Array<(
+      { __typename?: 'LintResult' }
+      & Pick<LintResult, 'ruleName' | 'message' | 'line' | 'column'>
+    )>> }
+  )> }
+);
+
+
+export const CreateProofreadingDocument: DocumentNode<CreateProofreadingMutation, CreateProofreadingMutationVariables> = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"createProofreading"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"proofreading"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AddProofreadingDataInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createProofreading"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"proofreading"},"value":{"kind":"Variable","name":{"kind":"Name","value":"proofreading"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"result"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ruleName"}},{"kind":"Field","name":{"kind":"Name","value":"message"}},{"kind":"Field","name":{"kind":"Name","value":"line"}},{"kind":"Field","name":{"kind":"Name","value":"column"}}]}}]}}]}}]};
+export const ProofreadingDataListDocument: DocumentNode<ProofreadingDataListQuery, ProofreadingDataListQueryVariables> = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"proofreadingDataList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"proofreadingDataList"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"result"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ruleName"}},{"kind":"Field","name":{"kind":"Name","value":"message"}},{"kind":"Field","name":{"kind":"Name","value":"line"}},{"kind":"Field","name":{"kind":"Name","value":"column"}}]}},{"kind":"Field","name":{"kind":"Name","value":"text"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]}}]};

--- a/packages/front/graphql/queries/createProofreading.graphql
+++ b/packages/front/graphql/queries/createProofreading.graphql
@@ -1,10 +1,6 @@
 mutation createProofreading($proofreading: AddProofreadingDataInput!) {
   createProofreading(proofreading: $proofreading) {
-    dataId
     text
-    user {
-      userName
-    }
     result {
       ruleName
       message

--- a/packages/front/graphql/queries/proofreadingDataList.graphql
+++ b/packages/front/graphql/queries/proofreadingDataList.graphql
@@ -1,0 +1,15 @@
+query proofreadingDataList {
+  proofreadingDataList {
+    user {
+      name
+    }
+    result {
+      ruleName
+      message
+      line
+      column
+    }
+    text
+    createdAt
+  }
+}

--- a/packages/front/package-lock.json
+++ b/packages/front/package-lock.json
@@ -1155,6 +1155,37 @@
         "@chakra-ui/utils": "1.0.2"
       }
     },
+    "@chakra-ui/icons": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-1.0.3.tgz",
+      "integrity": "sha512-YfBeG6TNSvBvzr/2RaVYMwYfMUtbS2nJ2YVygRELkAhQ8h0mUbTcNfw2YgUbY3H2BVfuRp9qCnbf6kp2evuh7A==",
+      "requires": {
+        "@chakra-ui/icon": "1.0.3",
+        "@types/react": "^17.0.0"
+      },
+      "dependencies": {
+        "@chakra-ui/icon": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-1.0.3.tgz",
+          "integrity": "sha512-wiNbipXLtwlItmtEf136xlgNjtFZuVOZBw1kM01Nk81fhe3lz+IsrEZW/Iyw1z0yzjrFkENR56TP+P3GVBLVwg==",
+          "requires": {
+            "@chakra-ui/utils": "1.1.0"
+          }
+        },
+        "@chakra-ui/utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-1.1.0.tgz",
+          "integrity": "sha512-QiX6HqQpv+oE4lRaPhDYRhrYI2ijAsNDpKhZeOeUh6hBXWIayzMB62iN0QANeMqynPz413TU5RR2c+WGwyax6g==",
+          "requires": {
+            "@types/lodash.mergewith": "4.6.6",
+            "@types/object-assign": "4.0.30",
+            "css-box-model": "1.2.1",
+            "lodash.mergewith": "4.6.2",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
     "@chakra-ui/image": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-1.0.2.tgz",
@@ -3827,14 +3858,12 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
       "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5059,7 +5088,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
       "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.0"
@@ -5711,6 +5739,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-react-context": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -6032,6 +6069,19 @@
         "mimic-response": "^2.0.0"
       }
     },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -6059,7 +6109,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -7293,7 +7342,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
       "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -7565,6 +7613,11 @@
       "dev": true,
       "optional": true
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -7618,8 +7671,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -8108,6 +8160,14 @@
         }
       }
     },
+    "is-arguments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -8171,8 +8231,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -8281,7 +8340,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
       "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -11338,11 +11396,19 @@
       "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
       "dev": true
     },
+    "object-is": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
+      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-path": {
       "version": "0.11.5",
@@ -11809,6 +11875,11 @@
         "tslib": "^1.10.0"
       }
     },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -12246,6 +12317,25 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "react-datepicker": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-3.4.1.tgz",
+      "integrity": "sha512-ASyVb7UmVx1vzeITidD7Cr/EXRXhKyjjbSkBndPc1MipYq4rqQ3eMFgvRQzpsXc3JmIMFgICm7nmN6Otc1GE/Q==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "date-fns": "^2.0.1",
+        "prop-types": "^15.7.2",
+        "react-onclickoutside": "^6.9.0",
+        "react-popper": "^1.3.4"
+      },
+      "dependencies": {
+        "date-fns": {
+          "version": "2.16.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
+          "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
+        }
+      }
+    },
     "react-dom": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
@@ -12278,6 +12368,25 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-onclickoutside": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.9.1.tgz",
+      "integrity": "sha512-fkeEZOym0eyf8pemEUFRI6rttdREwfYtNWpN9msWsYtwz0G+w1KeKODc466lKJtfMHn3u8gVmBnGPf2fQ9LxoQ=="
+    },
+    "react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "create-react-context": "^0.3.0",
+        "deep-equal": "^1.1.1",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
+      }
     },
     "react-refresh": {
       "version": "0.8.3",
@@ -12405,6 +12514,26 @@
       "version": "2.2.11",
       "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
       "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q=="
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        }
+      }
     },
     "registry-auth-token": {
       "version": "4.2.1",
@@ -14270,6 +14399,11 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
       "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
+    },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/packages/front/package.json
+++ b/packages/front/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.3.6",
+    "@chakra-ui/icons": "^1.0.3",
     "@chakra-ui/react": "^1.1.2",
     "@emotion/react": "^11.1.4",
     "@emotion/styled": "^11.0.0",
@@ -19,6 +20,7 @@
     "next": "10.0.4",
     "next-auth": "^3.1.0",
     "react": "17.0.1",
+    "react-datepicker": "^3.4.1",
     "react-dom": "17.0.1"
   },
   "devDependencies": {

--- a/packages/front/src/components/atoms/BoldText.tsx
+++ b/packages/front/src/components/atoms/BoldText.tsx
@@ -1,0 +1,13 @@
+import { Text } from '@chakra-ui/react';
+
+type Props = {
+  text: string;
+};
+
+export const BoldText = ({ text }: Props) => {
+  return (
+    <Text align="left" ml="5" fontWeight="semibold" as="h4">
+      {text}
+    </Text>
+  );
+};

--- a/packages/front/src/components/atoms/BorderBox.tsx
+++ b/packages/front/src/components/atoms/BorderBox.tsx
@@ -5,7 +5,7 @@ type Props = {
   children: ReactNode;
 };
 
-export const LayoutBox = ({ children }: Props) => {
+export const BorderBox = ({ children }: Props) => {
   return (
     <Box border="1px" borderColor="gray.200" w="100%" p="5">
       {children}

--- a/packages/front/src/components/atoms/Calender.tsx
+++ b/packages/front/src/components/atoms/Calender.tsx
@@ -1,0 +1,26 @@
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+
+type Props = {
+  selectedDate: Date;
+  minDate?: Date;
+  maxDate: Date;
+  onChange: (date: Date) => void;
+};
+
+export const Calender = ({
+  selectedDate,
+  minDate = null,
+  maxDate,
+  onChange,
+}: Props) => {
+  return (
+    <DatePicker
+      dateFormat="yyyy/MM/dd"
+      selected={selectedDate}
+      minDate={minDate}
+      maxDate={maxDate}
+      onChange={onChange}
+    />
+  );
+};

--- a/packages/front/src/components/atoms/CenterContainer.tsx
+++ b/packages/front/src/components/atoms/CenterContainer.tsx
@@ -5,9 +5,5 @@ type Props = {
 };
 
 export const CenterContainer = ({ children }: Props) => {
-  return (
-    <Container maxW="xl" centerContent>
-      {children}
-    </Container>
-  );
+  return <Container centerContent>{children}</Container>;
 };

--- a/packages/front/src/components/atoms/GraySmallText.tsx
+++ b/packages/front/src/components/atoms/GraySmallText.tsx
@@ -1,0 +1,13 @@
+import { Text } from '@chakra-ui/react';
+
+type Props = {
+  text: string;
+};
+
+export const GraySmallText = ({ text }: Props) => {
+  return (
+    <Text align="left" ml="5" color="gray.500" fontSize="xs">
+      {text}
+    </Text>
+  );
+};

--- a/packages/front/src/components/atoms/InputTextarea.tsx
+++ b/packages/front/src/components/atoms/InputTextarea.tsx
@@ -13,6 +13,7 @@ export const InputTextarea = ({ value, onChange, placeholder }: Props) => {
       value={value}
       onChange={onChange}
       placeholder={placeholder}
+      minW="full"
       minH="xs"
     />
   );

--- a/packages/front/src/components/atoms/LayoutBox.tsx
+++ b/packages/front/src/components/atoms/LayoutBox.tsx
@@ -1,7 +1,8 @@
+import { ReactNode } from 'react';
 import { Box } from '@chakra-ui/react';
 
 type Props = {
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 export const LayoutBox = ({ children }: Props) => {

--- a/packages/front/src/components/atoms/NoBorderBox.tsx
+++ b/packages/front/src/components/atoms/NoBorderBox.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+import { Box } from '@chakra-ui/react';
+
+type Props = {
+  children: ReactNode;
+};
+
+export const NoBorderBox = ({ children }: Props) => {
+  return (
+    <Box w="100%" p="5">
+      {children}
+    </Box>
+  );
+};

--- a/packages/front/src/components/atoms/RankBadge.tsx
+++ b/packages/front/src/components/atoms/RankBadge.tsx
@@ -1,0 +1,23 @@
+import { Badge } from '@chakra-ui/react';
+
+type Props = {
+  rank: number;
+};
+
+const TOP_COLORS = {
+  1: 'yellow.300',
+  2: 'gray.300',
+  3: 'orange.600',
+};
+
+const DEFAULT_COLOR = 'black';
+
+export const RankBadge = ({ rank }: Props) => {
+  const color = TOP_COLORS[rank] || DEFAULT_COLOR;
+
+  return (
+    <Badge borderRadius="full" px="2" bg={color}>
+      {rank}
+    </Badge>
+  );
+};

--- a/packages/front/src/components/molecules/DataLintRuleNames.tsx
+++ b/packages/front/src/components/molecules/DataLintRuleNames.tsx
@@ -1,0 +1,22 @@
+import { RankBadge } from '@/components/atoms/RankBadge';
+import { NoBorderBox } from '@/components/atoms/NoBorderBox';
+import { BoldText } from '@/components/atoms/BoldText';
+import { GraySmallText } from '@/components/atoms/GraySmallText';
+
+type Props = {
+  rank: number;
+  ruleNameView: string;
+  usedCount: string;
+};
+
+export const DataLintRuleNames = ({ rank, ruleNameView, usedCount }: Props) => {
+  return (
+    <>
+      <RankBadge rank={rank}></RankBadge>
+      <NoBorderBox>
+        <BoldText text={ruleNameView}></BoldText>
+        <GraySmallText text={`${usedCount}回`}></GraySmallText>
+      </NoBorderBox>
+    </>
+  );
+};

--- a/packages/front/src/components/molecules/DataTextExample.tsx
+++ b/packages/front/src/components/molecules/DataTextExample.tsx
@@ -1,0 +1,34 @@
+import { BoldText } from '@/components/atoms/BoldText';
+import { NoBorderBox } from '@/components/atoms/NoBorderBox';
+import { NormalCode } from '@/components/atoms/NormalCode';
+import { RedCode } from '@/components/atoms/RedCode';
+
+type Props = {
+  index: number;
+  lintExampleTextList: {
+    targetLine: string;
+    lintResultColumn: number;
+  }[];
+};
+
+export const DataTextExample = ({ index, lintExampleTextList }: Props) => {
+  const targetLine = lintExampleTextList[index].targetLine;
+  const lintResultColumn = lintExampleTextList[index].lintResultColumn;
+  return (
+    <>
+      <BoldText text={'例'}></BoldText>
+      <NoBorderBox>
+        <NormalCode
+          text={targetLine.slice(0, lintResultColumn - 1)}
+        ></NormalCode>
+        <RedCode text={targetLine[lintResultColumn - 1]}></RedCode>
+        <NormalCode
+          text={targetLine.slice(
+            lintResultColumn,
+            targetLine.indexOf('。') + 1,
+          )}
+        ></NormalCode>
+      </NoBorderBox>
+    </>
+  );
+};

--- a/packages/front/src/components/molecules/DateFilterInputForm.tsx
+++ b/packages/front/src/components/molecules/DateFilterInputForm.tsx
@@ -1,4 +1,5 @@
-import { FormControl, FormLabel, HStack } from '@chakra-ui/react';
+import { ChangeEvent } from 'react';
+import { FormControl, FormLabel, HStack, Select } from '@chakra-ui/react';
 import { CalendarIcon } from '@chakra-ui/icons';
 import { BorderBox } from '@/components/atoms/BorderBox';
 import { Calender } from '@/components/atoms/Calender';
@@ -8,6 +9,9 @@ type Props = {
   startOnChange: (date: Date) => void;
   endSelectedDate: Date;
   endOnChange: (date: Date) => void;
+  selectedUser: string;
+  selectOnChange: (e: ChangeEvent<HTMLSelectElement>) => void;
+  selectOptions: string[];
 };
 
 export const DateFilterInputForm = ({
@@ -15,12 +19,15 @@ export const DateFilterInputForm = ({
   startOnChange,
   endSelectedDate,
   endOnChange,
+  selectedUser,
+  selectOnChange,
+  selectOptions,
 }: Props) => {
   return (
     <BorderBox>
       <HStack>
         <FormControl>
-          <FormLabel>開始日時</FormLabel>
+          <FormLabel>開始日</FormLabel>
           <CalendarIcon mr={3} mb={1} />
           <Calender
             selectedDate={startSelectedDate}
@@ -29,7 +36,7 @@ export const DateFilterInputForm = ({
           ></Calender>
         </FormControl>
         <FormControl>
-          <FormLabel>終了日時</FormLabel>
+          <FormLabel>終了日</FormLabel>
           <CalendarIcon mr={3} mb={1} />
           <Calender
             selectedDate={endSelectedDate}
@@ -39,6 +46,18 @@ export const DateFilterInputForm = ({
           ></Calender>
         </FormControl>
       </HStack>
+      <FormControl mt={5}>
+        <FormLabel>対象のユーザー</FormLabel>
+        <Select
+          value={selectedUser}
+          onChange={selectOnChange}
+          placeholder="指定なし"
+        >
+          {selectOptions.map((option,index) => (
+            <option key = {index} value={option}>{option}</option>
+          ))}
+        </Select>
+      </FormControl>
     </BorderBox>
   );
 };

--- a/packages/front/src/components/molecules/DateFilterInputForm.tsx
+++ b/packages/front/src/components/molecules/DateFilterInputForm.tsx
@@ -1,0 +1,44 @@
+import { FormControl, FormLabel, HStack } from '@chakra-ui/react';
+import { CalendarIcon } from '@chakra-ui/icons';
+import { BorderBox } from '@/components/atoms/BorderBox';
+import { Calender } from '@/components/atoms/Calender';
+
+type Props = {
+  startSelectedDate: Date;
+  startOnChange: (date: Date) => void;
+  endSelectedDate: Date;
+  endOnChange: (date: Date) => void;
+};
+
+export const DateFilterInputForm = ({
+  startSelectedDate,
+  startOnChange,
+  endSelectedDate,
+  endOnChange,
+}: Props) => {
+  return (
+    <BorderBox>
+      <HStack>
+        <FormControl>
+          <FormLabel>開始日時</FormLabel>
+          <CalendarIcon mr={3} mb={1} />
+          <Calender
+            selectedDate={startSelectedDate}
+            maxDate={endSelectedDate}
+            onChange={startOnChange}
+          ></Calender>
+        </FormControl>
+        <FormControl>
+          <FormLabel>終了日時</FormLabel>
+          <CalendarIcon mr={3} mb={1} />
+          <Calender
+            selectedDate={endSelectedDate}
+            minDate={startSelectedDate}
+            maxDate={new Date()}
+            onChange={endOnChange}
+          ></Calender>
+        </FormControl>
+      </HStack>
+    </BorderBox>
+  );
+};

--- a/packages/front/src/components/molecules/DateFilterInputForm.tsx
+++ b/packages/front/src/components/molecules/DateFilterInputForm.tsx
@@ -53,8 +53,10 @@ export const DateFilterInputForm = ({
           onChange={selectOnChange}
           placeholder="指定なし"
         >
-          {selectOptions.map((option,index) => (
-            <option key = {index} value={option}>{option}</option>
+          {selectOptions.map((option, index) => (
+            <option key={index} value={option}>
+              {option}
+            </option>
           ))}
         </Select>
       </FormControl>

--- a/packages/front/src/components/molecules/ProofreadingInputForm.tsx
+++ b/packages/front/src/components/molecules/ProofreadingInputForm.tsx
@@ -32,12 +32,14 @@ export const ProofreadingInputForm = ({
 
       <Stack mt={10} spacing={1}>
         {checkBoxItems.map((checkedItem, index, array) => (
-          <div key = {index}>
+          <div key={index}>
             <CheckBox
               isChecked={checkedItem}
               onChange={(e) => {
                 setCheckBoxItems(
-                  array.map((item, i) => (i === index ? e.target.checked : item)),
+                  array.map((item, i) =>
+                    i === index ? e.target.checked : item,
+                  ),
                 );
               }}
               label={ruleNames[index]}

--- a/packages/front/src/components/molecules/ProofreadingResultTable.tsx
+++ b/packages/front/src/components/molecules/ProofreadingResultTable.tsx
@@ -1,5 +1,5 @@
-import { LayoutBox } from '@/components/atoms/LayoutBox';
 import { Table, Tbody, Tr, Td } from '@chakra-ui/react';
+import { BorderBox } from '@/components/atoms/BorderBox';
 import { RedCode } from '@/components/atoms/RedCode';
 import { LintResult } from '@graphql/graphql-operations';
 
@@ -15,7 +15,7 @@ export const ProofreadingResultTable = ({
   proofreadResults,
 }: Props) => {
   return (
-    <LayoutBox>
+    <BorderBox>
       <Table variant="simple">
         <Tbody>
           {proofreadResults.map((v, index) => (
@@ -31,6 +31,6 @@ export const ProofreadingResultTable = ({
           ))}
         </Tbody>
       </Table>
-    </LayoutBox>
+    </BorderBox>
   );
 };

--- a/packages/front/src/components/molecules/ProofreadingResultText.tsx
+++ b/packages/front/src/components/molecules/ProofreadingResultText.tsx
@@ -1,4 +1,4 @@
-import { LayoutBox } from '@/components/atoms/LayoutBox';
+import { BorderBox } from '@/components/atoms/BorderBox';
 import { NormalCode } from '@/components/atoms/NormalCode';
 import { RedCode } from '@/components/atoms/RedCode';
 import { LintResult } from '@graphql/graphql-operations';
@@ -15,7 +15,7 @@ export const ProofreadingResultText = ({
   proofreadResults,
 }: Props) => {
   return (
-    <LayoutBox>
+    <BorderBox>
       {splitResponseTexts.map((row, rowIndex) => {
         const proofreadResultsInRow = proofreadResults.filter(
           (v) => v.line == rowIndex + 1,
@@ -76,6 +76,6 @@ export const ProofreadingResultText = ({
           </div>
         );
       })}
-    </LayoutBox>
+    </BorderBox>
   );
 };

--- a/packages/front/src/components/organisms/DataListComponent.tsx
+++ b/packages/front/src/components/organisms/DataListComponent.tsx
@@ -1,0 +1,98 @@
+import { useQuery } from '@apollo/client';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionIcon,
+  AccordionPanel,
+} from '@chakra-ui/react';
+import { CenterContainer } from '@/components/atoms/CenterContainer';
+import { DataTextExample } from '@/components/molecules/DataTextExample';
+import { DataLintRuleNames } from '@/components/molecules/DataLintRuleNames';
+import { LINT_RULES } from '@/lib/RuleNameData';
+import { ProofreadingDataListDocument } from '@graphql/graphql-operations';
+
+export const DataListComponent = () => {
+  const { loading: queryLoading, data: queryData } = useQuery(
+    ProofreadingDataListDocument,
+  );
+
+  const sortedRuleUsedCountList = (() => {
+    if (queryLoading) {
+      return [];
+    }
+
+    const ruleNames = queryData.proofreadingDataList
+      .map((proofreadingData) =>
+        proofreadingData.result.map((result) => result.ruleName),
+      )
+      .flat();
+    const ruleUsedCountHash = ruleNames.reduce((dict, val) => {
+      dict[val] = (dict[val] || 0) + 1;
+      return dict;
+    }, {});
+    const sortedRuleUsedCountList = Object.keys(ruleUsedCountHash)
+      .map((e) => ({ key: e, value: ruleUsedCountHash[e] }))
+      .sort((a, b) => {
+        if (a.value < b.value) return 1;
+        if (a.value > b.value) return -1;
+        return 0;
+      });
+    return sortedRuleUsedCountList;
+  })();
+
+  const lintExampleTextList = (() => {
+    if (!sortedRuleUsedCountList) {
+      return [];
+    }
+
+    return sortedRuleUsedCountList.map((hash) => {
+      const ruleName = hash.key;
+      const firstMatchProofreadingData = queryData.proofreadingDataList
+        .filter(
+          (data) =>
+            data.result.filter((result) => result.ruleName == ruleName).length >
+            0,
+        )
+        .sort((a, b) => {
+          if (a.createdAt < b.createdAt) return 1;
+          if (a.createdAt > b.createdAt) return -1;
+          return 0;
+        })[0];
+      const lintResult = firstMatchProofreadingData.result.filter(
+        (result) => result.ruleName == ruleName,
+      )[0];
+      const targetLine = firstMatchProofreadingData.text.split(/\r\n|\n|↵/)[
+        lintResult.line - 1
+      ];
+      const lintResultColumn = lintResult.column;
+
+      return { targetLine, lintResultColumn };
+    });
+  })();
+
+  return (
+    <CenterContainer>
+      <Accordion allowMultiple minW="full">
+        {sortedRuleUsedCountList.map((hash, index) => (
+          <AccordionItem key={index}>
+            <AccordionButton>
+              <DataLintRuleNames
+                rank={index + 1}
+                ruleNameView={LINT_RULES[hash.key]}
+                usedCount={hash.value}
+              ></DataLintRuleNames>
+              <AccordionIcon />
+            </AccordionButton>
+            <AccordionPanel pb={4}>
+              <DataTextExample
+                index={index}
+                lintExampleTextList={lintExampleTextList}
+              ></DataTextExample>
+            </AccordionPanel>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </CenterContainer>
+  );
+};

--- a/packages/front/src/components/organisms/ProofreadingComponent.tsx
+++ b/packages/front/src/components/organisms/ProofreadingComponent.tsx
@@ -12,11 +12,7 @@ import { SuccessAlert } from '@/components/atoms/SuccessAlert';
 import { ProofreadingInputForm } from '@/components/molecules/ProofreadingInputForm';
 import { ProofreadingResultText } from '@/components/molecules/ProofreadingResultText';
 import { ProofreadingResultTable } from '@/components/molecules/ProofreadingResultTable';
-
-export const RULE_NAMES_FOR_VIEW = [
-  'ら抜き言葉を使用しない',
-  '同じ助詞を連続して使用しない',
-];
+import { LINT_RULES } from '@/lib/RuleNameData';
 
 export const ProofreadingComponent = () => {
   const [text, setText] = useState('');
@@ -77,7 +73,7 @@ export const ProofreadingComponent = () => {
         buttonOnClick={proofreadingButtonOnClick}
         checkBoxItems={checkedItems}
         setCheckBoxItems={setCheckedItems}
-        ruleNames={RULE_NAMES_FOR_VIEW}
+        ruleNames={Object.values(LINT_RULES)}
       ></ProofreadingInputForm>
 
       {response.data && (

--- a/packages/front/src/components/templates/layout.tsx
+++ b/packages/front/src/components/templates/layout.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react';
+import { useSession } from 'next-auth/client';
+import { AppHead } from '@/components/atoms/AppHead';
+import { LoadingText } from '@/components/atoms/LoadingText';
+
+type Props = {
+  isLoading: boolean;
+  children: ReactNode;
+};
+
+export const Layout = ({ isLoading, children }: Props) => {
+  const [, sessionLoading] = useSession();
+
+  return (
+    <div className="page">
+      <AppHead></AppHead>
+
+      <header>{/* TODO: ヘッダー作る */}</header>
+      <main>
+        {isLoading || sessionLoading ? <LoadingText></LoadingText> : children}
+      </main>
+    </div>
+  );
+};

--- a/packages/front/src/lib/RuleNameData.ts
+++ b/packages/front/src/lib/RuleNameData.ts
@@ -1,10 +1,3 @@
-export const RULE_NAMES_FOR_VIEW = [
-  'ら抜き言葉を使用しない',
-  '同じ助詞を連続して使用しない',
-];
-
-export const RULE_NAMES = ['no-dropping-the-ra', 'no-doubled-joshi'];
-
 export const LINT_RULES = {
   'no-dropping-the-ra': 'ら抜き言葉を使用しない',
   'no-doubled-joshi': '同じ助詞を連続して使用しない',

--- a/packages/front/src/lib/RuleNameData.ts
+++ b/packages/front/src/lib/RuleNameData.ts
@@ -1,0 +1,11 @@
+export const RULE_NAMES_FOR_VIEW = [
+  'ら抜き言葉を使用しない',
+  '同じ助詞を連続して使用しない',
+];
+
+export const RULE_NAMES = ['no-dropping-the-ra', 'no-doubled-joshi'];
+
+export const LINT_RULES = {
+  'no-dropping-the-ra': 'ら抜き言葉を使用しない',
+  'no-doubled-joshi': '同じ助詞を連続して使用しない',
+};

--- a/packages/front/src/pages/index.tsx
+++ b/packages/front/src/pages/index.tsx
@@ -1,8 +1,6 @@
 import { useMutation } from '@apollo/client';
-import { useSession } from 'next-auth/client';
 import { CreateProofreadingDocument } from '@graphql/graphql-operations';
-import { AppHead } from '@/components/atoms/AppHead';
-import { LoadingText } from '@/components/atoms/LoadingText';
+import { Layout } from '@/components/templates/layout';
 import { AuthComponent } from '@/components/molecules/AuthComponent';
 import { ProofreadingComponent } from '@/components/organisms/ProofreadingComponent';
 
@@ -11,22 +9,10 @@ export default function Home() {
     CreateProofreadingDocument,
   );
 
-  const [, sessionLoading] = useSession();
-
   return (
-    <div>
-      <AppHead></AppHead>
-
-      <main>
-        {sessionLoading || mutationLoading ? (
-          <LoadingText></LoadingText>
-        ) : (
-          <div>
-            <AuthComponent></AuthComponent>
-            <ProofreadingComponent></ProofreadingComponent>
-          </div>
-        )}
-      </main>
-    </div>
+    <Layout isLoading={mutationLoading}>
+      <AuthComponent></AuthComponent>
+      <ProofreadingComponent></ProofreadingComponent>
+    </Layout>
   );
 }

--- a/packages/front/src/pages/show.tsx
+++ b/packages/front/src/pages/show.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from '@apollo/client';
+import { ProofreadingDataListDocument } from '@graphql/graphql-operations';
+import { Layout } from '@/components/templates/layout';
+import { DataListComponent } from '@/components/organisms/DataListComponent';
+
+export default function Show() {
+  const { loading: queryLoading } = useQuery(ProofreadingDataListDocument);
+
+  return (
+    <Layout isLoading={queryLoading}>
+      <DataListComponent></DataListComponent>
+    </Layout>
+  );
+}

--- a/packages/front/test/pages/index.spec.tsx
+++ b/packages/front/test/pages/index.spec.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { MockedProvider } from '@apollo/client/testing';
 import client, { Session } from 'next-auth/client';
 import Home from '@/pages/index';
-import { RULE_NAMES_FOR_VIEW } from '@/components/organisms/ProofreadingComponent';
+import { LINT_RULES } from '@/lib/RuleNameData';
 
 describe(`Home`, () => {
   it('should　render loading view', async () => {
@@ -61,17 +61,11 @@ describe(`Home`, () => {
         <Home />
       </MockedProvider>,
     );
-    expect(
-      screen.getByRole('textbox'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /送信/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /送信/i })).toBeInTheDocument();
 
-    RULE_NAMES_FOR_VIEW.forEach(name => {
-      expect(
-        screen.getByText(new RegExp(name)),
-      ).toBeInTheDocument();
+    Object.values(LINT_RULES).forEach((name) => {
+      expect(screen.getByText(new RegExp(name))).toBeInTheDocument();
     });
   });
 });

--- a/packages/front/test/pages/show.spec.tsx
+++ b/packages/front/test/pages/show.spec.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { MockedProvider } from '@apollo/client/testing';
+import client from 'next-auth/client';
+import Show from '@/pages/show';
+import { ProofreadingDataListDocument } from '@graphql/graphql-operations';
+import { LINT_RULES } from '@/lib/RuleNameData';
+
+describe(`Show`, () => {
+  beforeEach(() => {
+    client['useSession'] = jest.fn().mockReturnValue([null, false]);
+  });
+
+  it('should render DateFilterInput view', async () => {
+    const mocks = [
+      {
+        request: {
+          query: ProofreadingDataListDocument,
+        },
+        result: {
+          data: {
+            proofreadingDataList: [],
+          },
+        },
+      },
+    ];
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Show />
+      </MockedProvider>,
+    );
+
+    expect(await screen.findByText(/開始日/i)).toBeInTheDocument();
+    expect(await screen.findByText(/終了日/i)).toBeInTheDocument();
+    expect(await screen.findByText(/対象のユーザー/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole('combobox', { name: /対象のユーザー/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('should render DateTextExample view', async () => {
+    const yesterDay = new Date();
+    yesterDay.setDate(new Date().getDate() - 1);
+
+    const testText = 'testText';
+
+    const mocks = [
+      {
+        request: {
+          query: ProofreadingDataListDocument,
+        },
+        result: {
+          data: {
+            proofreadingDataList: [
+              {
+                createdAt: yesterDay.toISOString(),
+                text: testText,
+                user: { name: '' },
+                result: [
+                  {
+                    line: 1,
+                    column: 1,
+                    message: '',
+                    ruleName: Object.keys(LINT_RULES)[0],
+                  },
+                  {
+                    line: 1,
+                    column: 2,
+                    message: '',
+                    ruleName: Object.keys(LINT_RULES)[0],
+                  },
+                  {
+                    line: 1,
+                    column: 3,
+                    message: '',
+                    ruleName: Object.keys(LINT_RULES)[1],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    ];
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Show />
+      </MockedProvider>,
+    );
+
+    expect(
+      await screen.findByRole('heading', {
+        name: new RegExp(Object.values(LINT_RULES)[0]),
+      }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/2回/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', {
+        name: new RegExp(Object.values(LINT_RULES)[1]),
+      }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/1回/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# 概要
過去に校正した結果を表示する画面を作成する。
ルール毎にエラーの回数を計測する。
期間とユーザーで抽出できる。

# 関連 Issue
#10 

# 変更内容
- pages/showに結果表示画面の作成
- DateのInputForm用にreact-datepickerの追加

# 確認事項
- [x] 必要な情報が描画されている
![image](https://user-images.githubusercontent.com/40588536/104940303-e4c5e980-59f4-11eb-850c-160e6f6aa464.png)

- [x] 開始日・終了日時を指定することで、データを絞り込める
![image](https://user-images.githubusercontent.com/40588536/104940497-2a82b200-59f5-11eb-9128-e4096a573a65.png)


- [x] 「現在のログイン中のユーザー」を指定することで、データを絞り込める
![image](https://user-images.githubusercontent.com/40588536/104940556-3ff7dc00-59f5-11eb-906b-902659023ac0.png)
![image](https://user-images.githubusercontent.com/40588536/104940569-46865380-59f5-11eb-923d-5bbd880180ef.png)
