### PR TITLE
ゲストログイン機能の実装

### DIFF
--- a/packages/front/src/components/atoms/AuthSignIn.tsx
+++ b/packages/front/src/components/atoms/AuthSignIn.tsx
@@ -11,6 +11,14 @@ export const AuthSignIn = () => {
       >
         Sign in
       </button>
+      <button
+        onClick={async (e) => {
+          e.preventDefault();
+          await signIn("credentials");
+        }}
+      >
+        ゲストログイン
+      </button>
     </div>
   );
 };

--- a/packages/front/src/pages/api/auth/[...nextauth].ts
+++ b/packages/front/src/pages/api/auth/[...nextauth].ts
@@ -7,6 +7,15 @@ const options = {
       clientId: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
     }),
+    Providers.Credentials({
+      name: "Credential",
+      async authorize() {
+        const user = { name: 'ゲストユーザー', email: 'guest@example.com' }
+        return user
+      },
+      credentials: {
+     }
+    })
   ],
 };
 

--- a/packages/front/test/pages/index.spec.tsx
+++ b/packages/front/test/pages/index.spec.tsx
@@ -30,6 +30,9 @@ describe(`Home`, () => {
     expect(
       screen.getByRole('button', { name: /sign in/i }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: /ゲストログイン/i}),
+    ).toBeInTheDocument();
   });
 
   it('should render login view', async () => {


### PR DESCRIPTION
# 概要
自分のGoogleアカウントを使わなくても機能を扱えるように、ゲストログイン機能を実装する。

# 関連 Issue
#10 

# 変更内容
- ProvidersにCredentialsを追加
- ゲストログイン用のボタンの追加

# 確認事項
- [x] 個人情報の入力なしでログインできる
![image](https://user-images.githubusercontent.com/40588536/105143604-6a55b080-5b3f-11eb-9ac4-627ef76585d6.png)

# 補足
デザインはあとで一括で調整する。本PRはあくまで機能の追加に留める。