### PR TITLE
NGワードとテンプレワードの実装(サーバー側)

### DIFF
--- a/packages/front/graphql/graphql-operations.ts
+++ b/packages/front/graphql/graphql-operations.ts
@@ -14,10 +14,19 @@ export type Scalars = {
   DateTime: any;
 };
 
+export type Word = {
+  __typename?: 'word';
+  wordId: Scalars['ID'];
+  wordText: Scalars['String'];
+  userId: Scalars['Float'];
+};
+
 export type User = {
   __typename?: 'User';
   id: Scalars['ID'];
   proofreadingDataList: Array<ProofreadingData>;
+  ngWords: Array<Word>;
+  templateWords: Array<Word>;
   name: Scalars['String'];
   email: Scalars['String'];
 };
@@ -45,11 +54,23 @@ export type ProofreadingData = {
 export type Query = {
   __typename?: 'Query';
   proofreadingDataList: Array<ProofreadingData>;
+  findUser: User;
+};
+
+
+export type QueryFindUserArgs = {
+  userArgs: FindUserArgs;
+};
+
+export type FindUserArgs = {
+  userEmail: Scalars['String'];
 };
 
 export type Mutation = {
   __typename?: 'Mutation';
   createProofreading: ProofreadingData;
+  createNgWord: Word;
+  createTemplateWord: Word;
 };
 
 
@@ -57,11 +78,25 @@ export type MutationCreateProofreadingArgs = {
   proofreading: AddProofreadingDataInput;
 };
 
+
+export type MutationCreateNgWordArgs = {
+  wordInput: AddUserWordInput;
+};
+
+
+export type MutationCreateTemplateWordArgs = {
+  wordInput: AddUserWordInput;
+};
+
 export type AddProofreadingDataInput = {
   text: Scalars['String'];
   userEmail: Scalars['String'];
-  userName: Scalars['String'];
   ruleNames: Array<Scalars['String']>;
+};
+
+export type AddUserWordInput = {
+  userEmail: Scalars['String'];
+  wordText: Scalars['String'];
 };
 
 export type CreateProofreadingMutationVariables = Exact<{

--- a/packages/front/src/components/organisms/ProofreadingComponent.tsx
+++ b/packages/front/src/components/organisms/ProofreadingComponent.tsx
@@ -52,7 +52,6 @@ export const ProofreadingComponent = () => {
       text: text,
       ruleNames: selectRuleNames,
       userEmail: session.user.email,
-      userName: session.user.name,
     };
     const response = await createProofreading({
       variables: { proofreading: proofreading },

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -11,14 +11,16 @@ model User {
   id                   Int                @id @default(autoincrement())
   name                 String
   email                String             @unique
+  ngWords              NgWord[]
   proofreadingDataList ProofreadingData[]
+  templateWords        TemplateWord[]
 }
 
 model ProofreadingData {
   dataId    Int          @id @default(autoincrement())
   text      String?
-  userId    Int?
   createdAt DateTime     @default(now()) @map("created_at")
+  userId    Int?
   user      User?        @relation(fields: [userId], references: [id])
   result    LintResult[]
 
@@ -32,4 +34,24 @@ model LintResult {
   line                 Int
   column               Int
   proofreadingDataList ProofreadingData[]
+}
+
+model NgWord {
+  wordId   Int    @id @default(autoincrement())
+  wordText String
+  userId   Int
+  user     User   @relation(fields: [userId], references: [id])
+
+  @@unique([wordText, userId], name: "userNgWord")
+  @@index([userId], name: "userId")
+}
+
+model TemplateWord {
+  wordId   Int    @id @default(autoincrement())
+  wordText String
+  userId   Int
+  user     User   @relation(fields: [userId], references: [id])
+
+  @@unique([wordText, userId], name: "userTemplateWord")
+  @@index([userId], name: "userId")
 }

--- a/packages/server/src/dto/proofreadingData.dto.ts
+++ b/packages/server/src/dto/proofreadingData.dto.ts
@@ -6,8 +6,6 @@ export class AddProofreadingDataInput {
   text: string;
   @Field((_type) => String)
   userEmail: string;
-  @Field((_type) => String)
-  userName: string;
   @Field((_type) => [String])
   ruleNames: string[];
 }

--- a/packages/server/src/dto/user.dto.ts
+++ b/packages/server/src/dto/user.dto.ts
@@ -1,0 +1,15 @@
+import { InputType, Field } from '@nestjs/graphql';
+
+@InputType()
+export class FindUserArgs {
+  @Field((_type) => String)
+  userEmail: string;
+}
+
+@InputType()
+export class AddUserWordInput {
+  @Field((_type) => String)
+  userEmail: string;
+  @Field((_type) => String)
+  wordText: string;
+}

--- a/packages/server/src/dto/user.dto.ts
+++ b/packages/server/src/dto/user.dto.ts
@@ -7,6 +7,13 @@ export class FindUserArgs {
 }
 
 @InputType()
+export class AddUserInput {
+  @Field((_type) => String)
+  userEmail: string;
+  @Field((_type) => String)
+  userName: string;
+}
+@InputType()
 export class AddUserWordInput {
   @Field((_type) => String)
   userEmail: string;

--- a/packages/server/src/models/user.model.ts
+++ b/packages/server/src/models/user.model.ts
@@ -1,5 +1,6 @@
 import { ObjectType, Field, ID } from '@nestjs/graphql';
 import { ProofreadingData } from '@/models/proofreadingData.model';
+import { Word } from '@/models/word.model';
 
 @ObjectType()
 export class User {
@@ -9,4 +10,8 @@ export class User {
   email: string;
   @Field((_type) => [ProofreadingData])
   proofreadingDataList: ProofreadingData[];
+  @Field((_type) => [Word])
+  ngWords: Word[];
+  @Field((_type) => [Word])
+  templateWords: Word[];
 }

--- a/packages/server/src/models/word.model.ts
+++ b/packages/server/src/models/word.model.ts
@@ -1,0 +1,10 @@
+import { ObjectType, Field, ID } from '@nestjs/graphql';
+
+@ObjectType()
+export class Word {
+  @Field((_type) => ID)
+  wordId: number;
+  @Field((_type) => String)
+  wordText: String;
+  userId: number;
+}

--- a/packages/server/src/modules/app.module.ts
+++ b/packages/server/src/modules/app.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
 import { join } from 'path';
 import { ProofreadingDataModule } from '@/modules/proofreadingData.module';
+import { UserModule } from '@/modules/user.module';
 
 @Module({
   imports: [
     ProofreadingDataModule,
+    UserModule,
     GraphQLModule.forRoot({
       autoSchemaFile: join(process.cwd(), 'src/schema.gql'),
       debug: true,

--- a/packages/server/src/modules/user.module.ts
+++ b/packages/server/src/modules/user.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { UserResolver } from '@/resolvers/user.resolver';
+import { PrismaService } from '@/services/prisma.service';
+import { UserService } from '@/services/user.service';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [UserService, PrismaService, UserResolver],
+})
+export class UserModule {}

--- a/packages/server/src/resolvers/proofreadingData.resolver.ts
+++ b/packages/server/src/resolvers/proofreadingData.resolver.ts
@@ -5,18 +5,18 @@ import { AddProofreadingDataInput } from '@/dto/proofreadingData.dto';
 
 @Resolver((of) => ProofreadingData)
 export class ProofreadingDataResolver {
-  constructor(private ProofreadingDataService: ProofreadingDataService) {}
+  constructor(private proofreadingDataService: ProofreadingDataService) {}
 
   @Query((returns) => [ProofreadingData])
   async proofreadingDataList() {
-    return await this.ProofreadingDataService.findMany();
+    return await this.proofreadingDataService.findMany();
   }
 
   @Mutation((returns) => ProofreadingData)
   async createProofreading(
     @Args('proofreading') proofreading: AddProofreadingDataInput,
   ) {
-    return await this.ProofreadingDataService.create(
+    return await this.proofreadingDataService.create(
       proofreading.text,
       proofreading.ruleNames,
       proofreading.userEmail,

--- a/packages/server/src/resolvers/proofreadingData.resolver.ts
+++ b/packages/server/src/resolvers/proofreadingData.resolver.ts
@@ -20,7 +20,6 @@ export class ProofreadingDataResolver {
       proofreading.text,
       proofreading.ruleNames,
       proofreading.userEmail,
-      proofreading.userName,
     );
   }
 }

--- a/packages/server/src/resolvers/user.resolver.ts
+++ b/packages/server/src/resolvers/user.resolver.ts
@@ -2,7 +2,7 @@ import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
 import { User } from '@/models/user.model';
 import { Word } from '@/models/word.model';
 import { UserService } from '@/services/user.service';
-import { AddUserWordInput, FindUserArgs } from '@/dto/user.dto';
+import { AddUserInput, AddUserWordInput, FindUserArgs } from '@/dto/user.dto';
 
 @Resolver((of) => User)
 export class UserResolver {
@@ -13,13 +13,27 @@ export class UserResolver {
     return await this.userService.findByEmail(userArgs.userEmail);
   }
 
+  @Mutation((returns) => User)
+  async createUser(@Args('userInput') userInput: AddUserInput) {
+    return await this.userService.create(
+      userInput.userEmail,
+      userInput.userName,
+    );
+  }
+
   @Mutation((returns) => Word)
   async createNgWord(@Args('wordInput') wordInput: AddUserWordInput) {
-    return await this.userService.createNgWord(wordInput.userEmail, wordInput.wordText);
+    return await this.userService.createNgWord(
+      wordInput.userEmail,
+      wordInput.wordText,
+    );
   }
 
   @Mutation((returns) => Word)
   async createTemplateWord(@Args('wordInput') wordInput: AddUserWordInput) {
-    return await this.userService.createTemplateWord(wordInput.userEmail, wordInput.wordText);
+    return await this.userService.createTemplateWord(
+      wordInput.userEmail,
+      wordInput.wordText,
+    );
   }
 }

--- a/packages/server/src/resolvers/user.resolver.ts
+++ b/packages/server/src/resolvers/user.resolver.ts
@@ -1,0 +1,25 @@
+import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
+import { User } from '@/models/user.model';
+import { Word } from '@/models/word.model';
+import { UserService } from '@/services/user.service';
+import { AddUserWordInput, FindUserArgs } from '@/dto/user.dto';
+
+@Resolver((of) => User)
+export class UserResolver {
+  constructor(private userService: UserService) {}
+
+  @Query((returns) => User)
+  async findUser(@Args('userArgs') userArgs: FindUserArgs) {
+    return await this.userService.findByEmail(userArgs.userEmail);
+  }
+
+  @Mutation((returns) => Word)
+  async createNgWord(@Args('wordInput') wordInput: AddUserWordInput) {
+    return await this.userService.createNgWord(wordInput.userEmail, wordInput.wordText);
+  }
+
+  @Mutation((returns) => Word)
+  async createTemplateWord(@Args('wordInput') wordInput: AddUserWordInput) {
+    return await this.userService.createTemplateWord(wordInput.userEmail, wordInput.wordText);
+  }
+}

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -50,6 +50,7 @@ input FindUserArgs {
 
 type Mutation {
   createProofreading(proofreading: AddProofreadingDataInput!): ProofreadingData!
+  createUser(userInput: AddUserInput!): User!
   createNgWord(wordInput: AddUserWordInput!): Word!
   createTemplateWord(wordInput: AddUserWordInput!): Word!
 }
@@ -58,6 +59,11 @@ input AddProofreadingDataInput {
   text: String!
   userEmail: String!
   ruleNames: [String!]!
+}
+
+input AddUserInput {
+  userEmail: String!
+  userName: String!
 }
 
 input AddUserWordInput {

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -2,9 +2,17 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+type Word {
+  wordId: ID!
+  wordText: String!
+  userId: Float!
+}
+
 type User {
   id: ID!
   proofreadingDataList: [ProofreadingData!]!
+  ngWords: [Word!]!
+  templateWords: [Word!]!
   name: String!
   email: String!
 }
@@ -33,15 +41,26 @@ scalar DateTime
 
 type Query {
   proofreadingDataList: [ProofreadingData!]!
+  findUser(userArgs: FindUserArgs!): User!
+}
+
+input FindUserArgs {
+  userEmail: String!
 }
 
 type Mutation {
   createProofreading(proofreading: AddProofreadingDataInput!): ProofreadingData!
+  createNgWord(wordInput: AddUserWordInput!): Word!
+  createTemplateWord(wordInput: AddUserWordInput!): Word!
 }
 
 input AddProofreadingDataInput {
   text: String!
   userEmail: String!
-  userName: String!
   ruleNames: [String!]!
+}
+
+input AddUserWordInput {
+  userEmail: String!
+  wordText: String!
 }

--- a/packages/server/src/services/lintResult.service.ts
+++ b/packages/server/src/services/lintResult.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { TextLintEngine } from 'textlint';
+import { TextlintMessage } from '@textlint/types';
 
 @Injectable()
 export class LintResultService {
-  async create(text: string, ruleNames: string[]) {
+  async execute(text: string, ruleNames: string[]) {
     const options = {
       rules: ruleNames,
       rulesConfig: ruleNames.reduce(
@@ -15,8 +16,13 @@ export class LintResultService {
 
     const results = await engine.executeOnText(text);
     const messages = results[0].messages;
+
+    return messages;
+  }
+
+  createPrismaDict(lintMessages: TextlintMessage[]) {
     const dict = {
-      create: messages.reduce(
+      create: lintMessages.reduce(
         (obj, message) =>
           obj.concat([
             {

--- a/packages/server/src/services/proofreadingData.service.ts
+++ b/packages/server/src/services/proofreadingData.service.ts
@@ -21,6 +21,9 @@ export class ProofreadingDataService {
   }
 
   async create(text: string, ruleNames: string[], userEmail: string) {
+    const user = this.userService.createPrismaDict(userEmail);
+    const message = await this.resultService.execute(text, ruleNames);
+    const result = this.resultService.createPrismaDict(message);
     const prismaProofreadingData = await this.prismaService.proofreadingData.create(
       {
         data: { text: text, user: user, result: result },

--- a/packages/server/src/services/proofreadingData.service.ts
+++ b/packages/server/src/services/proofreadingData.service.ts
@@ -20,14 +20,7 @@ export class ProofreadingDataService {
     });
   }
 
-  async create(
-    text: string,
-    ruleNames: string[],
-    userEmail: string,
-    userName: string,
-  ) {
-    const user = await this.userService.create(userEmail, userName);
-    const result = await this.resultService.create(text, ruleNames);
+  async create(text: string, ruleNames: string[], userEmail: string) {
     const prismaProofreadingData = await this.prismaService.proofreadingData.create(
       {
         data: { text: text, user: user, result: result },

--- a/packages/server/src/services/user.service.ts
+++ b/packages/server/src/services/user.service.ts
@@ -1,14 +1,59 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from '@/services/prisma.service';
 
 @Injectable()
 export class UserService {
+  constructor(private prismaService: PrismaService) {}
+
+  async findByEmail(userEmail: string) {
+    const user = await this.prismaService.user.findUnique({
+      where: {
+        email: userEmail,
+      },
+      include: {
+        ngWords: true,
+        templateWords: true,
+      },
+    });
+    return user;
+  }
+
   async create(userEmail: string, userName: string) {
+    const user = await this.prismaService.user.create({
+      data: {
+        email: userEmail,
+        name: userName,
+      },
+    });
+    return user;
+  }
+
+  createPrismaDict(userEmail: string) {
     const dict = {
-      connectOrCreate: {
-        where: { email: userEmail },
-        create: { email: userEmail, name: userName },
+      connect: {
+        email: userEmail,
       },
     };
     return dict;
+  }
+
+  async createNgWord(userEmail: string, wordText: string) {
+    const ngWord = await this.prismaService.ngWord.create({
+      data: {
+        wordText: wordText,
+        user: this.createPrismaDict(userEmail),
+      },
+    });
+    return ngWord;
+  }
+
+  async createTemplateWord(userEmail: string, wordText: string) {
+    const templateWord = await this.prismaService.templateWord.create({
+      data: {
+        wordText: wordText,
+        user: this.createPrismaDict(userEmail),
+      },
+    });
+    return templateWord;
   }
 }

--- a/packages/server/test/services/lintResult.service.spec.ts
+++ b/packages/server/test/services/lintResult.service.spec.ts
@@ -11,20 +11,49 @@ describe('LintResultService', () => {
     lintResultService = moduleRef.get<LintResultService>(LintResultService);
   });
 
-  describe('create', () => {
+  describe('execute', () => {
     it('should return lint result', async () => {
       const testWrongText = '私はご飯を食べれます。';
       const testLintRules = ['no-dropping-the-ra'];
-      const expected = {
-        create: [
-          { message: 'ら抜き言葉を使用しています。', column: 8, line: 1 },
-        ],
-      };
+      const expected = [
+        {
+          column: 8,
+          fix: undefined,
+          index: 7,
+          line: 1,
+          message: 'ら抜き言葉を使用しています。',
+          ruleId: testLintRules[0],
+          severity: 2,
+          type: 'lint',
+        },
+      ];
 
-      const result = await lintResultService.create(
+      const result = await lintResultService.execute(
         testWrongText,
         testLintRules,
       );
+      expect(result).toMatchObject(expected);
+    });
+  });
+
+  describe('createPrismaDict', () => {
+    it('should return formatted dict for prisma', async () => {
+      const messages = [
+        {
+          type: '',
+          ruleId: '',
+          message: '',
+          column: 1,
+          line: 1,
+          index: 1,
+          severity: 2,
+        },
+      ];
+      const expected = {
+        create: [{ message: '', column: 1, line: 1, ruleName: '' }],
+      };
+
+      const result = lintResultService.createPrismaDict(messages);
       expect(result).toMatchObject(expected);
     });
   });

--- a/packages/server/test/services/proofreadingData.service.spec.ts
+++ b/packages/server/test/services/proofreadingData.service.spec.ts
@@ -43,20 +43,32 @@ describe('ProofreadingDataService', () => {
       const testText = 'test';
       const testRules = ['testRule'];
       const testEmail = 'test@test.com';
-      const testName = 'testName';
       const testReturnUsers = {
-        connectOrCreate: {
-          where: { email: testEmail },
-          create: { email: testEmail, name: testName },
+        connect: {
+          email: testEmail,
         },
       };
 
-      const testReturnResults = { create: ['testResults'] };
+      const testReturnExecuteMessages = [
+        {
+          column: 1,
+          index: 1,
+          line: 1,
+          message: '',
+          ruleId: testRules[0],
+          severity: 1,
+          type: '',
+        },
+      ];
       const expectedArg = {
         data: {
           text: testText,
           user: testReturnUsers,
-          result: testReturnResults,
+          result: {
+            create: [
+              { column: 1, line: 1, message: '', ruleName: testRules[0] },
+            ],
+          },
         },
         include: {
           user: true,
@@ -64,23 +76,16 @@ describe('ProofreadingDataService', () => {
         },
       };
 
-      const UserServiceCreateMock = jest.fn(() =>
-        Promise.resolve(testReturnUsers),
-      );
-      userService['create'] = UserServiceCreateMock;
+      const UserServiceCreateMock = jest.fn(() => testReturnUsers);
+      userService['createPrismaDict'] = UserServiceCreateMock;
       const lintResultServiceCreateMock = jest.fn(() =>
-        Promise.resolve(testReturnResults),
+        Promise.resolve(testReturnExecuteMessages),
       );
-      lintResultService['create'] = lintResultServiceCreateMock;
+      lintResultService['execute'] = lintResultServiceCreateMock;
       const prismaCreateMock = jest.fn();
       prismaService.proofreadingData['create'] = prismaCreateMock;
 
-      await proofreadingDataService.create(
-        testText,
-        testRules,
-        testEmail,
-        testName,
-      );
+      await proofreadingDataService.create(testText, testRules, testEmail);
       expect(UserServiceCreateMock).toHaveBeenCalled();
       expect(lintResultServiceCreateMock).toHaveBeenCalled();
       expect(prismaCreateMock).toHaveBeenCalled();

--- a/packages/server/test/services/user.service.spec.ts
+++ b/packages/server/test/services/user.service.spec.ts
@@ -1,29 +1,128 @@
 import { Test } from '@nestjs/testing';
 import { UserService } from '@/services/user.service';
+import { PrismaService } from '@/services/prisma.service';
 
 describe('UserService', () => {
   let userService: UserService;
+  let prismaService: PrismaService;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
-      providers: [UserService],
+      providers: [UserService, PrismaService],
     }).compile();
     userService = moduleRef.get<UserService>(UserService);
+    prismaService = moduleRef.get<PrismaService>(PrismaService);
+  });
+
+  describe('findByEmail', () => {
+    it('should call prisma user findUnique', async () => {
+      const testEmail = 'test@test.com';
+      const expectedArg = {
+        where: {
+          email: testEmail,
+        },
+        include: {
+          ngWords: true,
+          templateWords: true,
+        },
+      };
+      const prismaFindUniqueMock = jest.fn();
+      prismaService.user['findUnique'] = prismaFindUniqueMock;
+
+      await userService.findByEmail(testEmail);
+      expect(prismaFindUniqueMock).toHaveBeenCalled();
+      expect(prismaFindUniqueMock.mock.calls[0][0]).toEqual(expectedArg);
+    });
   });
 
   describe('create', () => {
-    it('should return formated dict for prisma', async () => {
+    it('should call prisma user create', async () => {
       const testEmail = 'test@test.com';
       const testName = 'testName';
-      const expected = {
-        connectOrCreate: {
-          where: { email: testEmail },
-          create: { email: testEmail, name: testName },
+
+      const expectedArg = {
+        data: {
+          email: testEmail,
+          name: testName,
         },
       };
 
-      const rules = await userService.create(testEmail, testName);
+      const prismaCreateMock = jest.fn();
+      prismaService.user['create'] = prismaCreateMock;
+
+      await userService.create(testEmail, testName);
+      expect(prismaCreateMock).toHaveBeenCalled();
+      expect(prismaCreateMock.mock.calls[0][0]).toEqual(expectedArg);
+    });
+  });
+
+  describe('createPrismaDict', () => {
+    it('should return formatted dict for prisma', () => {
+      const testEmail = 'test@test.com';
+      const expected = {
+        connect: {
+          email: testEmail,
+        },
+      };
+
+      const rules = userService.createPrismaDict(testEmail);
       expect(rules).toMatchObject(expected);
+    });
+  });
+
+  describe('createNgWord', () => {
+    it('should call prisma ngWord create', async () => {
+      const testEmail = 'test@test.com';
+      const testWordText = 'testName';
+
+      const testReturnUsers = {
+        connect: {
+          email: testEmail,
+        },
+      };
+      const expectedArg = {
+        data: {
+          wordText: testWordText,
+          user: testReturnUsers,
+        },
+      };
+
+      const prismaCreateMock = jest.fn();
+      prismaService.ngWord['create'] = prismaCreateMock;
+      const UserServiceCreateMock = jest.fn(() => testReturnUsers);
+      userService['createPrismaDict'] = UserServiceCreateMock;
+
+      await userService.createNgWord(testEmail, testWordText);
+      expect(prismaCreateMock).toHaveBeenCalled();
+      expect(prismaCreateMock.mock.calls[0][0]).toEqual(expectedArg);
+    });
+  });
+
+  describe('createTemplateWord', () => {
+    it('should call prisma templateWord create', async () => {
+      const testEmail = 'test@test.com';
+      const testWordText = 'testName';
+
+      const testReturnUsers = {
+        connect: {
+          email: testEmail,
+        },
+      };
+      const expectedArg = {
+        data: {
+          wordText: testWordText,
+          user: testReturnUsers,
+        },
+      };
+
+      const prismaCreateMock = jest.fn();
+      prismaService.templateWord['create'] = prismaCreateMock;
+      const UserServiceCreateMock = jest.fn(() => testReturnUsers);
+      userService['createPrismaDict'] = UserServiceCreateMock;
+
+      await userService.createTemplateWord(testEmail, testWordText);
+      expect(prismaCreateMock).toHaveBeenCalled();
+      expect(prismaCreateMock.mock.calls[0][0]).toEqual(expectedArg);
     });
   });
 });


### PR DESCRIPTION
# 概要
NGワードとテンプレワード機能のために、サーバーでデータを保存する仕組みを実装

# 関連 Issue
#10 

# 変更内容
- ngWordsとtemplateWordsスキーマの追加
- UserスキーマのfindとcreateAPIの作成
  - createUser
  - findUser 
- ngWordsとtemplateWordsスキーマのcreateAPIの作成
  - createNgWord
  - createTemplateWord  
- LintResultServiceのcreate処理を分割

# 確認事項
- [x] 新規作成APIの動作確認
![image](https://user-images.githubusercontent.com/40588536/106144528-a6c88280-61b7-11eb-8133-42161ca36644.png)
![image](https://user-images.githubusercontent.com/40588536/106145500-f9566e80-61b8-11eb-8ea2-bd0c2a97df95.png)
![image](https://user-images.githubusercontent.com/40588536/106145533-01161300-61b9-11eb-9c0c-b468acf08fdf.png)
- [x] リファクタリングしたAPIの動作確認
![image](https://user-images.githubusercontent.com/40588536/106145674-2c006700-61b9-11eb-85b6-fc06e589b74d.png)
